### PR TITLE
Fix moved definition of SIOCGSTAMP in linux API headers >= 5.2

### DIFF
--- a/elements/userlevel/fromdevice.cc
+++ b/elements/userlevel/fromdevice.cc
@@ -53,6 +53,8 @@
 # include <net/ethernet.h>
 #endif
 
+# include <linux/sockios.h>
+
 CLICK_DECLS
 
 FromDevice::FromDevice()

--- a/elements/userlevel/rawsocket.cc
+++ b/elements/userlevel/rawsocket.cc
@@ -43,6 +43,8 @@
 
 #include "fakepcap.hh"
 
+#include <linux/sockios.h>
+
 CLICK_DECLS
 
 RawSocket::RawSocket()


### PR DESCRIPTION
Linux API headers beginning with version 5.2 moved the definition of SIOCGSTAMP to linux/sockios.h.